### PR TITLE
Add the possibility to use unsplash photo as featured images

### DIFF
--- a/scripts/sidebar/components/photo/style.scss
+++ b/scripts/sidebar/components/photo/style.scss
@@ -38,18 +38,26 @@
 
 .dropit-sidebar-photo__toolbar {
   position: absolute;
-  bottom: 10px;
-  right: 10px;
-
-  display: grid;
-  grid-auto-flow: column;
-  grid-gap: 10px;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  text-align: right;
 
   .components-icon-button {
     display: inline-flex;
-    opacity: 0.5;
+    opacity: 0.9;
     box-shadow: none !important;
     border: none !important;
+    border-radius: 0 !important;
+    align-items: center;
+    justify-content: center;
+    height: 30px;
+    width: 33.333%;
+    border-right: 1px solid #ccc !important;
+
+    &:last-child {
+      border-right: none !important;
+    }
 
     &.button-primary {
       color: #fff !important;
@@ -59,7 +67,7 @@
       padding-top: 2px;
     }
 
-    &:hover {
+    &:hover:not(:disabled) {
       opacity: 1;
     }
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,8 @@ const wpDependencies = [
   "i18n",
   "editPost",
   "plugins",
-  "apiRequest"
+  "apiRequest",
+  "editor"
 ];
 wpDependencies.forEach(wpDependency => {
   externals["@wordpress/" + wpDependency] = {


### PR DESCRIPTION
This PR adds the possibility to set the unsplash.com photos as featured images on post types that support it.

It also tweaks the design of the buttons a bit.

<img width="267" alt="screen shot 2018-06-30 at 18 40 54" src="https://user-images.githubusercontent.com/272444/42127710-48543c30-7c95-11e8-87b3-a2c597d9b077.png">

closes #6 