### PR TITLE
Fixing a typo

### DIFF
--- a/scripts/sidebar/components/photo/index.js
+++ b/scripts/sidebar/components/photo/index.js
@@ -121,7 +121,7 @@ class Photo extends Component {
                   className="button"
                   icon="format-image"
                   onClick={this.useAsAFeaturedImage}
-                  label={__("Use a featured image", "dropit")}
+                  label={__("Use as featured image", "dropit")}
                   disabled={image && featuredImageId === image.id}
                 />
               </PostFeaturedImageCheck>


### PR DESCRIPTION
I believe that this is a typo. "Use a featured image" should be "Use as featured image".

![screen shot 2018-08-22 at 10 38 40 am](https://user-images.githubusercontent.com/359867/44470405-99c30480-a5f7-11e8-887e-af6610ae6087.png)
